### PR TITLE
fix(FEC-12952): Image and Youbora integration

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -11,7 +11,7 @@
 
 You can find  [here](https://github.com/kaltura/playkit-js/blob/master/src/event/event-type.js) the full list of player events
 
-Of these, the following are supported in an image entry:
+Of these, the following are supported in an image playback:
 
 ### Non-Durational Image Events
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,6 +8,7 @@
   - [Image in a Playlist](#Image-in-a-Playlist)
   - [Events](#Image-Events)
   - [Advertisements](#Advertisements)
+  - [Analytics](#Analytics)
 - [Full working code example](https://github.com/kaltura/playkit-js-image-player/tree/master/demo)
 
 ## Overview
@@ -139,6 +140,15 @@ See [here](./events.md) The full list of image events
 which means you can configure any type (**pre-roll**,  **mid-roll** and **post-roll**) of ad using the [IMA Plugin](https://github.com/kaltura/playkit-js-ima#readme)
 
 **Non-Durational Image** only **pre-roll** ads are supported
+
+### Analytics
+
+Image entry can be integrated with [Kava](https://github.com/kaltura/playkit-js-kava#readme) and [Youbora](https://github.com/kaltura/playkit-js-youbora#readme) analytics plugins,
+In this case the reported **PlaybackType** info will be `'img'` (instead of `'Vod'` or `'Live'`)
+
+You can find [here](./events.md#kava-analytics-events) the full list of Kava Analytics events supported in Image Entry playback.
+
+
 
 ## Full working code example
 

--- a/src/image-player.ts
+++ b/src/image-player.ts
@@ -19,6 +19,7 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
   private _playbackRate: number;
   private timer: Timer;
   private isFirstPlay: boolean;
+  private isLoadingStart: boolean;
 
   constructor(source: any, config: any) {
     super();
@@ -26,6 +27,7 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
     this._playbackRate = 1;
     this.timer = new Timer();
     this.isFirstPlay = true;
+    this.isLoadingStart = false;
     this.createImageElement();
     this.init(source, config);
   }
@@ -156,11 +158,6 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
 
   public attachMediaSource(): void {}
 
-  public destroy(): void {
-    this.reset();
-    this.el.remove();
-  }
-
   public detach(): void {}
 
   public detachMediaSource(): void {}
@@ -199,14 +196,6 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
     this.dispatchEvent(new FakeEvent(EventType.PAUSE));
   }
 
-  public reset(): void {
-    this.eventManager.removeAll();
-    // this.el.setAttribute('src', '');
-    this.isFirstPlay = true;
-    this.playbackRate = 1;
-    this.timer.reset();
-  }
-
   public resetAllCues(): void {}
 
   public restore(source: any, config: any): void {
@@ -221,6 +210,10 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
   public selectTextTrack(textTrack: TextTrack): void {}
 
   public selectVideoTrack(videoTrack: any): void {}
+
+  public get src(): string {
+    return this.isLoadingStart && this.source ? this.source.url : '';
+  }
 
   public get id(): string {
     return ImagePlayer.id;
@@ -269,5 +262,22 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
 
   public getThumbnail(time: number): null {
     return null;
+  }
+
+  public getDrmInfo(): null {
+    return null;
+  }
+
+  public reset(): void {
+    this.eventManager.removeAll();
+    this.isFirstPlay = true;
+    this.isLoadingStart = false;
+    this.playbackRate = 1;
+    this.timer.reset();
+  }
+
+  public destroy(): void {
+    this.reset();
+    this.el.remove();
   }
 }

--- a/src/image-player.ts
+++ b/src/image-player.ts
@@ -50,6 +50,7 @@ export class ImagePlayer extends FakeEventTarget implements IEngine {
   }
 
   public async load(startTime: number): Promise<{ tracks: [] }> {
+    this.isLoadingStart = true;
     return new Promise((resolve, reject) => {
       this.el.onload = (): void => {
         resolve({ tracks: [] });


### PR DESCRIPTION
### Description of the Changes

Youbora uses the player public API Like get src() getDrmInfo which is exposed by the engine interface which is not implemented yet by the engine

solves FEC-12952

related prs:
https://github.com/kaltura/playkit-js-youbora/pull/108
https://github.com/kaltura/playkit-js/pull/702

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
