### PR TITLE
feat(FEC-12953): Add configuration option to change the default playlist image item duration

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,48 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <title>Image Player</title>
-        <script src="https://cdnapisec.kaltura.com/p/1804331/embedPlaykitJs/uiconf_id/51444112"></script>
-        <script src="https://unpkg.com/@playkit-js/image-player@latest/dist/playkit-image-player.js"></script>
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <script src="https://raw.githack.com/kaltura/kaltura-player-js/master/dist/kaltura-ovp-player.js"></script>
+    <script src="https://unpkg.com/@playkit-js/image-player@canary/dist/playkit-image-player.js"></script>
     <!--    For local environment-->
     <!--    <script src="http://localhost:8081/kaltura-ovp-player.js" type="text/javascript"></script>-->
     <!--    <script src="../playkit-image-player.js"></script>-->
-    <style>
-      @keyframes glowing {
-        0% {
-          background-color: #2ba805;
-          box-shadow: 0 0 3px #2ba805;
-        }
-        50% {
-          background-color: #49e819;
-          box-shadow: 0 0 10px #49e819;
-        }
-        100% {
-          background-color: #2ba805;
-          box-shadow: 0 0 3px #2ba805;
-        }
-      }
-
-      .btn-active {
-        animation: glowing 800ms infinite;
-      }
-
-      .btn-demo {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        justify-content: center;
-        align-items: center;
-        border-radius: 3px;
-        padding: 1px;
-        margin: 3px;
-        cursor: pointer;
-        background-color: #2ba805;
-      }
-    </style>
   </head>
   <body>
     <div id="player-placeholder" style="width: 640px; height: 360px"></div>
-    <div style="width: 640px;margin-top:10px;display: flex;font-family: Sans-serif">
+    <div style="width: 640px; margin-top: 10px; display: flex; font-family: Sans-serif">
       <div class="btn-demo demo-1" onclick="loadMedia(1)">
         <span>None Durational img</span>
         <span>loadMedia()</span>
@@ -73,7 +41,7 @@
       player.loadMedia({ entryId: '1_ktrfo5hl' });
 
       function loadImagesPlaylist(btnNum) {
-        player.loadPlaylist({playlistId: '1_1b6sw5ze'}, {options: {autoContinue: true}});
+        player.loadPlaylist({ playlistId: '1_1b6sw5ze' }, { options: { imageDuration: 20 } });
         toggleActiveClass(btnNum);
       }
 
@@ -83,7 +51,7 @@
       }
 
       function loadMedia(btnNum) {
-        player.loadMedia({entryId: '1_zere6vs4'});
+        player.loadMedia({ entryId: '1_zere6vs4' });
         toggleActiveClass(btnNum);
       }
 

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,0 +1,31 @@
+.btn-active {
+    animation: glowing 800ms infinite;
+}
+
+.btn-demo {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    border-radius: 3px;
+    padding: 1px;
+    margin: 3px;
+    cursor: pointer;
+    background-color: #2ba805;
+}
+
+@keyframes glowing {
+    0% {
+        background-color: #2ba805;
+        box-shadow: 0 0 3px #2ba805;
+    }
+    50% {
+        background-color: #49e819;
+        box-shadow: 0 0 10px #49e819;
+    }
+    100% {
+        background-color: #2ba805;
+        box-shadow: 0 0 3px #2ba805;
+    }
+}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -130,9 +130,9 @@ You can read more about Thumbnail API configuration Parameters options [here](ht
 
 Images played as part of a playlist will always be played in **Durational** mode (with a default duration of 5 second)
 
-The duration will be the same for all items in the playlist
+The image duration will be the same for all image items in the playlist
 
-If you want to change the default playlist items duration you can set it through the player options configuration, As in the example below:
+If you want to change the default playlist image items duration you can set it through the player options configuration, as in the example below:
 
 ```js
 player.loadPlaylist({ playlistId: '1_1b6sw5ze' }, { options: { imageDuration: 20 } });

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -130,6 +130,14 @@ You can read more about Thumbnail API configuration Parameters options [here](ht
 
 Images played as part of a playlist will always be played in **Durational** mode (with a default duration of 5 second)
 
+The duration will be the same for all items in the playlist
+
+If you want to change the default playlist items duration you can set it through the player options configuration, As in the example below:
+
+```js
+player.loadPlaylist({ playlistId: '1_1b6sw5ze' }, { options: { imageDuration: 20 } });
+```
+
 ### Image Events
 
 See [here](./events.md) The full list of image events


### PR DESCRIPTION
### Description of the Changes

Currently the only way to set an image duration while playing a single media is by overriding the duration property, but this is not possible when playing playlist by entry so we need to add configuration option in loadPlaylist() public API

solves FEC-12953

related pr: https://github.com/kaltura/kaltura-player-js/pull/607

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
